### PR TITLE
Integrate OTX SDK 

### DIFF
--- a/OTX_CONFIG_FILE
+++ b/OTX_CONFIG_FILE
@@ -1,8 +1,9 @@
 [otx]
 # AlienVault OTX API key
 otx_api_key = PUT API KEY HERE
-# AlienVault API URL
-otx_url = https://otx.alienvault.com/api/v1
+
+# Location of cache directory is cached method is desired.  if this setting is not set, cache will not be used
+cache_dir =
 
 [proxy]
 # Leave blank if you do not use a proxy

--- a/OTX_Siphon.py
+++ b/OTX_Siphon.py
@@ -6,7 +6,7 @@
 # Create an account and curate your subscriptions
 # https://otx.alienvault.com
 #
-# AUTHOR Karma: https://github.com/KarmaIncarnate
+# Original AUTHOR Karma: https://github.com/KarmaIncarnate
 # Adapted from OTX 2 CRITS by lolnate @ https://github.com/lolnate/otx2crits
 # Using AlienVault SDK for OTXv2 https://github.com/AlienVault-OTX/OTX-Python-SDK
 
@@ -39,9 +39,6 @@ class OTX_Siphon(object):
                 proxy_https=self.config.get('proxy', 'https'),  # Set HTTPS proxy if present in config file,
             )
 
-        if dev:
-            print('Developer options not yet programmed.')  # Need to program developer parameters
-
         self.modified_since = None  # Set pulse range to those modified in last x days
         if days:
             print('Searching for pulses modified in last {}' ' days'.format(days))
@@ -73,9 +70,6 @@ class OTX_Siphon(object):
                     # and/or write methods. Need to parse the indicator_data
                     # Probably use some sort of mapping
                     result = [event_title, created, i['type'], i['indicator'], reference]
-                    # print('Indicator data: ' + str(indicator_data))
-                    # print('--------------------------------------')
-                    # print(result)
                     wr.writerow(result)
 
     def parse_config(self, location):
@@ -101,11 +95,6 @@ class OTX_Siphon(object):
             print('Config file found automatically')
             return self.parse_config(config_file)
         config_file = os.path.join(os.path.expanduser('~'), '.otx_config')  # Check path for .otx_config file
-        # Walk or?
-        # for root, dirs, files in os.walk(os.path.expanduser('~'))
-        #     for file in files:
-        #         if file.endswith(.otx_config):
-        #             return self.parse_config(config_file)
         return self.parse_config(config_file)
 
 
@@ -115,7 +104,6 @@ def main():
     argparser.add_argument(
         '-d', dest='days', default=None, type=int, help='Specify the max range of pulses grabbed ' 'in days. (days old)'
     )
-    argparser.add_argument('--dev', dest='dev', action='store_true', default=False, help='Use dev options.')
     args = argparser.parse_args()
 
     siphon = OTX_Siphon(dev=args.dev, config=args.config, days=args.days)

--- a/OTX_Siphon.py
+++ b/OTX_Siphon.py
@@ -31,6 +31,7 @@ class OTX_Siphon(object):
                 cache_dir=self.cache_dir,
                 proxy=self.config.get('proxy', 'http') or None,  # Set HTTP proxy if present in config file
                 proxy_https=self.config.get('proxy', 'https') or None,  # Set HTTPS proxy if present in config file,
+                max_age=365,  # don't populate the cache with pulses older than 365 days
             )
         else:
             self.otx = OTXv2(

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # OTX_Siphon
 Pulls pulses from AlienVault subscription list; parses and dumps indicators to csv file.
+
+This script requires the OTX SDK to be installed.  You can do this using
+"pip install OTXv2"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@ Pulls pulses from AlienVault subscription list; parses and dumps indicators to c
 
 This script requires the OTX SDK to be installed.  You can do this using
 "pip install OTXv2"
+
+Note that you can use a cache directory setting in the config file, and if it is present
+then the cached version of the OTX SDK will be used.  The first time the cached SDK is used, 
+it may take some time to sync the cache, but after that it shouldn't be too bad,
+and in general using the cached method results in a lot less requests to OTX


### PR DESCRIPTION
I thought this would be a bit simpler and somewhat more future-proof if I integrated the OTX SDK into it.  I made minimal changes while doing so, and also fixed a bug with the output.csv - it was getting over-written with each downloaded pulse.

There are two ways to use the OTX SDK, the "normal" way and the "cached" way - I included both.  If you define a cache directory, it will use the cached method.  The cached method downloads your whole subscription to the cache (up to 1 year old pulses), so the first time you run the cached version there will be a significant delay while the cache is populated.  After that, whenever you run the script it will only sync new pulses to the cache.  This means that in general when you run this script it will make a lot less requests to OTX, since it should be able to find much of what you're looking for in the cache.